### PR TITLE
Update xml namespace

### DIFF
--- a/build/phpdox.xml
+++ b/build/phpdox.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<phpdox xmlns="http://phpdox.de/config" silent="false">
+<phpdox xmlns="http://xml.phpdox.net/config" silent="false">
 
     <project name="YourProject" source="app" workdir="${basedir}/build/api/xml">
 


### PR DESCRIPTION
The following error message is displayed when using the file as-is:

``` shell

phpdox:
     [exec] phpDox 0.7.0-dirty - Copyright (C) 2010 - 2014 by Arne Blankerts
     [exec]
     [exec]
     [exec] An error occured while trying to load the configuration file:
     [exec]     File './phpdox.xml' uses an outdated xml namespace. Please update the xmlns to 'http://xml.phpdox.net/config'
     [exec]
     [exec] Using --skel might get you started.
     [exec]
     [exec] Result: 3

```
