### PR TITLE
Warning: PHPLoc enrichment not enabled or phploc.xml not found in phpDox

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -33,8 +33,10 @@
             </sequential>
             <antcall target="phpcb" />
             <antcall target="phpcpd" />
-            <antcall target="phpdox" />
-            <antcall target="phploc" />
+            <sequential>
+                <antcall target="phploc" />
+                <antcall target="phpdox" />
+            </sequential>
         </parallel>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -144,6 +144,8 @@
         <exec executable="phploc">
            <arg value="--log-csv" />
            <arg value="${build-dir}/logs/phploc.csv" />
+           <arg value="--log-xml" />
+           <arg value="${build-dir}/logs/phploc.xml" />
            <arg path="${src-dir}" />
         </exec>
     </target>

--- a/build/phpdox.xml
+++ b/build/phpdox.xml
@@ -4,6 +4,9 @@
     <collector backend="parser" />
     <generator output="${basedir}/api">
       <build engine="html" output="html"/>
+      <enrich base="${basedir}/logs">
+        <source type="phploc" />
+      </enrich>
     </generator>
   </project>
 </phpdox>


### PR DESCRIPTION
Since we already have a phploc support in the build, it could be nice to have phpdox output enriched by the phploc data.
This will make the warning from the subject go away from the phpdox output and provide a phploc data at the phpdox Overview page.